### PR TITLE
Add blueetl_core.parallel.isolated()

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,19 @@
 Changelog
 =========
 
+Version 0.2.1
+-------------
+
+New Features
+~~~~~~~~~~~~
+
+- Add ``blueetl_core.parallel.isolated()`` to execute a function in a separate subprocess.
+
+Improvements
+~~~~~~~~~~~~
+
+- If the env variable ``BLUEETL_SUBPROCESS_LOGGING_LEVEL`` is empty or not defined, then the log level of the subprocesses is inherited from the parent.
+
 Version 0.2.0
 -------------
 

--- a/src/blueetl_core/constants.py
+++ b/src/blueetl_core/constants.py
@@ -9,5 +9,6 @@ BLUEETL_JOBLIB_VERBOSE = "BLUEETL_JOBLIB_VERBOSE"
 BLUEETL_JOBLIB_JOBS = "BLUEETL_JOBLIB_JOBS"
 # JobLib backend (loky, multiprocessing, threading). If not overridden, it uses by default: loky
 BLUEETL_JOBLIB_BACKEND = "BLUEETL_JOBLIB_BACKEND"
-# Subprocess logging level. If empty or not defined, fallback to the default level WARNING.
+# Logging level to be configured in subprocesses.
+# If empty or not defined, use the effective log level of the parent process (recommended).
 BLUEETL_SUBPROCESS_LOGGING_LEVEL = "BLUEETL_SUBPROCESS_LOGGING_LEVEL"

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -1,0 +1,22 @@
+from functools import partial
+
+import pytest
+
+from blueetl_core import parallel as test_module
+
+
+def _myfunc(n):
+    return n * n
+
+
+@pytest.mark.parametrize("jobs", [1, 3, None])
+def test_run_parallel(jobs):
+    tasks = [test_module.Task(partial(_myfunc, n=i)) for i in range(3)]
+    result = test_module.run_parallel(tasks=tasks, jobs=jobs)
+    assert result == [0, 1, 4]
+
+
+def test_isolated():
+    func = test_module.isolated(_myfunc)
+    result = func(n=2)
+    assert result == 4


### PR DESCRIPTION
Other: If the env variable ``BLUEETL_SUBPROCESS_LOGGING_LEVEL`` is empty or not defined, then the log level of the subprocesses is inherited from the parent.