### PR TITLE
In parallel.isolated(), allow to execute the function in the same process

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+Version 0.2.2
+-------------
+
+Improvements
+~~~~~~~~~~~~
+
+- In ``blueetl_core.parallel.isolated()``, execute the function in the same process if ``BLUEETL_JOBLIB_JOBS`` is set to ``1``.
+
 Version 0.2.1
 -------------
 

--- a/src/blueetl_core/constants.py
+++ b/src/blueetl_core/constants.py
@@ -6,6 +6,7 @@
 # If not overridden, the value depends on logging: 0 if loglevel >= logging.WARNING else 10
 BLUEETL_JOBLIB_VERBOSE = "BLUEETL_JOBLIB_VERBOSE"
 # Number of concurrent jobs. If not overridden, it uses by default: os.cpu_count() // 2
+# If 1, do not use subprocesses (mainly for testing or debugging).
 BLUEETL_JOBLIB_JOBS = "BLUEETL_JOBLIB_JOBS"
 # JobLib backend (loky, multiprocessing, threading). If not overridden, it uses by default: loky
 BLUEETL_JOBLIB_BACKEND = "BLUEETL_JOBLIB_BACKEND"

--- a/src/blueetl_core/parallel.py
+++ b/src/blueetl_core/parallel.py
@@ -143,6 +143,9 @@ def isolated(func):
             seed=None,
             ppid=os.getpid(),
         )
+        if os.getenv(BLUEETL_JOBLIB_JOBS) == "1":
+            # execute the task in the current process and return the result
+            return task(ctx)
         executor = get_reusable_executor(max_workers=1, reuse=False)
         try:
             future = executor.submit(task, ctx)

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -9,14 +9,35 @@ def _myfunc(n):
     return n * n
 
 
-@pytest.mark.parametrize("jobs", [1, 3, None])
-def test_run_parallel(jobs):
+@pytest.mark.parametrize(
+    "jobs, jobs_env",
+    [
+        (1, None),
+        (3, None),
+        (None, None),
+        (None, 1),
+        (None, 3),
+    ],
+)
+def test_run_parallel(monkeypatch, jobs, jobs_env):
+    if jobs_env is not None:
+        monkeypatch.setenv("BLUEETL_JOBLIB_JOBS", str(jobs_env))
+    else:
+        monkeypatch.delenv("BLUEETL_JOBLIB_JOBS", raising=False)
     tasks = [test_module.Task(partial(_myfunc, n=i)) for i in range(3)]
     result = test_module.run_parallel(tasks=tasks, jobs=jobs)
     assert result == [0, 1, 4]
 
 
-def test_isolated():
+def test_isolated_in_sub_process(monkeypatch):
+    monkeypatch.delenv("BLUEETL_JOBLIB_JOBS", raising=False)
+    func = test_module.isolated(_myfunc)
+    result = func(n=2)
+    assert result == 4
+
+
+def test_isolated_in_main_process(monkeypatch):
+    monkeypatch.setenv("BLUEETL_JOBLIB_JOBS", "1")
     func = test_module.isolated(_myfunc)
     result = func(n=2)
     assert result == 4


### PR DESCRIPTION
In ``blueetl_core.parallel.isolated()``, execute the function in the same process if ``BLUEETL_JOBLIB_JOBS`` is set to ``1``.